### PR TITLE
feat: refactor whole structure consisting with sync package

### DIFF
--- a/chan.go
+++ b/chan.go
@@ -5,37 +5,32 @@ import (
 	"time"
 )
 
-// ChanMutex provides interfaces of spinlock and trylock implemented by channel.
-type ChanMutex interface {
-	// Lock acquires the lock.
-	// If it is currently held by others, Lock will wait until it has a chance to acquire it.
-	Lock()
-	// TryLock attempts to acquire the lock without blocking.
-	// Return false if someone is holding it now.
-	TryLock() bool
-	// TryLockWithTimeout attempts to acquire the lock within a period of time.
-	// Return false if spending time is more than duration and no chance to acquire it.
-	TryLockWithTimeout(time.Duration) bool
-	// TryLockWithContext attempts to acquire the lock, blocking until resources
-	// are available or ctx is done (timeout or cancellation)
-	TryLockWithContext(ctx context.Context) bool
-	// Unlock releases the lock
-	Unlock()
-}
-
-type chanMutex struct {
+// ChanMutex is the struct implementing Mutex by channel.
+type ChanMutex struct {
 	lockChan chan struct{}
 }
 
-func (m *chanMutex) Lock() {
+// NewChanMutex returns ChanMutex.
+func NewChanMutex() *ChanMutex {
+	return &ChanMutex{
+		lockChan: make(chan struct{}, 1),
+	}
+}
+
+// Lock acquires the lock.
+// If it is currently held by others, Lock will wait until it has a chance to acquire it.
+func (m *ChanMutex) Lock() {
 	m.lockChan <- struct{}{}
 }
 
-func (m *chanMutex) Unlock() {
+// Unlock releases the lock.
+func (m *ChanMutex) Unlock() {
 	<-m.lockChan
 }
 
-func (m *chanMutex) TryLock() bool {
+// TryLock attempts to acquire the lock without blocking.
+// Return false if someone is holding it now.
+func (m *ChanMutex) TryLock() bool {
 	select {
 	case m.lockChan <- struct{}{}:
 		return true
@@ -44,7 +39,9 @@ func (m *chanMutex) TryLock() bool {
 	}
 }
 
-func (m *chanMutex) TryLockWithContext(ctx context.Context) bool {
+// TryLockWithContext attempts to acquire the lock, blocking until resources
+// are available or ctx is done (timeout or cancellation).
+func (m *ChanMutex) TryLockWithContext(ctx context.Context) bool {
 	select {
 	case m.lockChan <- struct{}{}:
 		return true
@@ -54,16 +51,11 @@ func (m *chanMutex) TryLockWithContext(ctx context.Context) bool {
 	}
 }
 
-func (m *chanMutex) TryLockWithTimeout(duration time.Duration) bool {
+// TryLockWithTimeout attempts to acquire the lock within a period of time.
+// Return false if spending time is more than duration and no chance to acquire it.
+func (m *ChanMutex) TryLockWithTimeout(duration time.Duration) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 
 	return m.TryLockWithContext(ctx)
-}
-
-// NewChanMutex returns ChanMutex lock
-func NewChanMutex() ChanMutex {
-	return &chanMutex{
-		lockChan: make(chan struct{}, 1),
-	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,53 @@
+package lock_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/viney-shih/go-lock"
+)
+
+func ExampleChanMutex() {
+	// set RWMutex with CAS mechanism (CASMutex).
+	var rwMut lock.RWMutex = lock.NewCASMutex()
+	// set default value
+	count := int32(0)
+
+	// block here
+	rwMut.Lock()
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		fmt.Println("Now is", atomic.AddInt32(&count, 1)) // Now is 1
+		rwMut.Unlock()
+	}()
+
+	// waiting for previous goroutine releasing the lock, and locking it again
+	rwMut.Lock()
+	fmt.Println("Now is", atomic.AddInt32(&count, 2)) // Now is 3
+
+	// TryLock without blocking
+	// Return false, because the lock is not released.
+	fmt.Println("Return", rwMut.TryLock())
+
+	// RTryLockWithTimeout without blocking
+	// Return false, because the lock is not released.
+	fmt.Println("Return", rwMut.RTryLockWithTimeout(50*time.Millisecond))
+
+	// TryLockWithContext without blocking
+	ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
+	defer cancel()
+	// Return false, because the lock is not released.
+	fmt.Println("Return", rwMut.TryLockWithContext(ctx))
+
+	// release the lock in the end.
+	rwMut.Unlock()
+
+	// Output:
+	// Now is 1
+	// Now is 3
+	// Return false
+	// Return false
+	// Return false
+}

--- a/lock.go
+++ b/lock.go
@@ -1,0 +1,53 @@
+// Package go-lock is a Golang library implementing an effcient read-write lock with the following built-in mechanism:
+// - Mutex with timeout mechanism
+// - Trylock
+// - No-starve read-write solution
+package lock
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Mutex is a mutual exclusion lock, and must not be copied after first use.
+type Mutex interface {
+	// Lock acquires the lock.
+	// If it is currently held by others, Lock will wait until it has a chance to acquire it.
+	Lock()
+	// TryLock attempts to acquire the lock without blocking.
+	// Return false if someone is holding it now.
+	TryLock() bool
+	// TryLockWithTimeout attempts to acquire the lock within a period of time.
+	// Return false if spending time is more than duration and no chance to acquire it.
+	TryLockWithTimeout(time.Duration) bool
+	// TryLockWithContext attempts to acquire the lock, blocking until resources
+	// are available or ctx is done (timeout or cancellation).
+	TryLockWithContext(ctx context.Context) bool
+	// Unlock releases the lock.
+	Unlock()
+}
+
+// RWMutex is a reader/writer mutual exclusion lock. The lock can be held by an arbitrary number of
+// readers or a single writer. It must not be copied after first use.
+type RWMutex interface {
+	Mutex
+
+	// RLock acquires the read lock.
+	// If it is currently held by others writing, RLock will wait until it has a chance to acquire it.
+	RLock()
+	// RTryLock attempts to acquire the read lock without blocking.
+	// Return false if someone is writing it now.
+	RTryLock() bool
+	// RTryLockWithTimeout attempts to acquire the read lock within a period of time.
+	// Return false if spending time is more than duration and no chance to acquire it.
+	RTryLockWithTimeout(time.Duration) bool
+	// RTryLockWithContext attempts to acquire the read lock, blocking until resources
+	// are available or ctx is done (timeout or cancellation).
+	RTryLockWithContext(ctx context.Context) bool
+	// RUnlock releases the read lock.
+	RUnlock()
+	// RLocker returns a Locker interface that implements the Lock and Unlock methods
+	// by calling rw.RLock and rw.RUnlock.
+	RLocker() sync.Locker
+}


### PR DESCRIPTION
# Description
- extract the interface consisting with `sync.Mutex` and `sync.RWMutex` .
- Refactor the coding style with the convention in Go.
- Add examples.

# Reference
- [sync.Mutex](https://pkg.go.dev/sync#Mutex)
- [sync.RWMutex](https://pkg.go.dev/sync#RWMutex)